### PR TITLE
Add GitHub labels: Release preparation AND New release

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -86,6 +86,14 @@
   description: This PR is ready to be merged
   color: "0ff40b"
 
+- name: 🔄 Release preparation
+  description: Preparing for a new release (version bump, release notes, etc.)
+  color: "f9c74f"
+
+- name: 🔄 New release
+  description: This PR into `stable` marks a new release
+  color: "f9c74f"
+
 - name: 🧪 Tests
   description: Improvements or additions to unit tests
   color: "9f2d60"


### PR DESCRIPTION
_This is a change to the GitHub repository configuration._

Added two new labels to the repository:
* 🔄 Release preparation
* 🔄 New release