### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -86,6 +86,14 @@
   description: This PR is ready to be merged
   color: "0ff40b"
 
+- name: 🔄 Release preparation
+  description: Preparing for a new release (version bump, release notes, etc.)
+  color: "f9c74f"
+
+- name: 🔄 New release
+  description: This PR into `stable` marks a new release
+  color: "f9c74f"
+
 - name: 🧪 Tests
   description: Improvements or additions to unit tests
   color: "9f2d60"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to crates.io
+
+on:
+  push:
+    branches:
+      - stable
+
+permissions:
+  contents: write
+  discussions: write
+
+
+jobs:
+  test:
+    name: Run tests and publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
+        with:
+          components: rustfmt, clippy
+
+      - name: Run RustFMT
+        uses: actions-rust-lang/rustfmt@559aa3035a47390ba96088dffa783b5d26da9326
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features
+
+      - name: Run tests
+        run: cargo test --verbose --all-targets --all-features
+
+      - name: Run documentation tests
+        run: cargo test --verbose --doc --all-features
+
+      - name: Get crate version
+        id: get_crate_info
+        run: |
+          CRATE_VERSION=$(grep '^version = ' Cargo.toml | head -n 1 | cut -d '"' -f 2)
+          echo "Crate error-stack-macros2"
+          echo "Crate Version: $CRATE_VERSION"
+          echo "crate_version=$CRATE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATESIO_API_TOKEN }}
+        run: cargo publish
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
+        with:
+          body_path: RELEASE.md
+          prerelease: true
+          name: "`error-stack-macros2` ${{ steps.get_crate_info.outputs.crate_version }}"
+          tag_name: v${{ steps.get_crate_info.outputs.crate_version }}
+          target_commitish: stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 
   workflow_dispatch:
 
+
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/testToStable.yml
+++ b/.github/workflows/testToStable.yml
@@ -1,0 +1,65 @@
+name: Run tests and check version on crates.io
+
+on:
+  pull_request:
+    branches:
+      - stable
+
+
+jobs:
+  test:
+    name: Run tests on PR into stable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
+        with:
+          components: rustfmt, clippy
+
+      - name: Run RustFMT
+        uses: actions-rust-lang/rustfmt@559aa3035a47390ba96088dffa783b5d26da9326
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features
+
+      - name: Run tests
+        run: cargo test --verbose --all-targets --all-features
+
+      - name: Run documentation tests
+        run: cargo test --verbose --doc --all-features
+
+
+  check-version:
+    name: Check version on crates.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Get crate version
+        id: get_crate_info
+        run: |
+          CRATE_VERSION=$(grep '^version = ' Cargo.toml | head -n 1 | cut -d '"' -f 2)
+          echo "Crate error-stack-macros2"
+          echo "Crate Version: $CRATE_VERSION"
+          echo "crate_version=$CRATE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already exists on crates.io
+        run: |
+          CRATE_VERSION="${{ steps.get_crate_info.outputs.crate_version }}"
+          API_URL="https://crates.io/api/v1/crates/error-stack-macros2/$CRATE_VERSION"
+
+          echo "Checking $API_URL"
+
+          if curl --head -f "$API_URL"; then
+            echo "Error: Version $CRATE_VERSION already exists on crates.io!"
+            echo "Please increment the version in Cargo.toml."
+            exit 1
+          else
+            echo "Version $CRATE_VERSION does not exist on crates.io. You're good to go!"
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "error-stack-macros2"
-version = "0.0.0-reserved"
+version = "0.1.0"
 dependencies = [
  "error-stack",
  "proc-macro2",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "error-stack-macros2-tests"
-version = "0.0.0-reserved"
+version = "0.1.0"
 dependencies = [
  "error-stack",
  "error-stack-macros2",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,56 @@
+# `error-stack-macros2` v0.1.0
+
+The very first development version of `error-stack-macros2` is finally here!
+
+## Features
+
+This version (0.1.0) offers a derive macro for the [`Error`](https://doc.rust-lang.org/stable/core/error/trait.Error.html) trait which encourages the best practices for defining [`error-stack`](https://crates.io/crates/error-stack) context types.
+
+Here's an example. This code:
+
+```rust
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
+
+#[derive(Debug)]
+pub enum CreditCardError {
+    InvalidInput(String),
+    Other,
+}
+
+impl Display for CreditCardError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::InvalidInput(_) => "credit card not found",
+            Self::Other => "failed to retrieve credit card",
+        };
+
+        f.write_str(msg)
+    }
+}
+
+impl Error for CreditCardError {}
+```
+
+...can now be reduced to this code:
+
+```rust
+use error_stack_macros2::Error;
+
+#[derive(Debug, Error)]
+pub enum CreditCardError {
+    #[display("credit card not found")]
+    InvalidInput(String),
+
+    #[display("failed to retrieve credit card")]
+    Other,
+}
+```
+
+This new release also means that we will now be listening to feedback and accepting new features (macros, obviously). We are also now committed to maintaining this macro going forward and keeping our dependencies up to date.
+
+## Previous release notes
+
+If you want to take a look at the notes from previous releases, go to [GitHub Releases](https://github.com/LuisFerLCC/error-stack-macros2/releases).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | ------- | --------- |
-| -       | -         |
+| 0.1.0   | ✅        |
 
 ## Report a vulnerability
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack-macros2"
-version = "0.0.0-reserved"
+version = "0.1.0"
 authors = ["LuisFerLCC"]
 edition = "2024"
 rust-version = "1.90.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack-macros2-tests"
-version = "0.0.0-reserved"
+version = "0.1.0"
 authors = ["LuisFerLCC"]
 edition = "2024"
 rust-version = "1.90.0"


### PR DESCRIPTION
# `error-stack-macros2` v0.1.0

The very first development version of `error-stack-macros2` is finally here!

## Features

This version (0.1.0) offers a derive macro for the [`Error`](https://doc.rust-lang.org/stable/core/error/trait.Error.html) trait which encourages the best practices for defining [`error-stack`](https://crates.io/crates/error-stack) context types.

Here's an example. This code:

```rust
use std::{
    error::Error,
    fmt::{self, Display, Formatter},
};

#[derive(Debug)]
pub enum CreditCardError {
    InvalidInput(String),
    Other,
}

impl Display for CreditCardError {
    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
        let msg = match self {
            Self::InvalidInput(_) => "credit card not found",
            Self::Other => "failed to retrieve credit card",
        };

        f.write_str(msg)
    }
}

impl Error for CreditCardError {}
```

...can now be reduced to this code:

```rust
use error_stack_macros2::Error;

#[derive(Debug, Error)]
pub enum CreditCardError {
    #[display("credit card not found")]
    InvalidInput(String),

    #[display("failed to retrieve credit card")]
    Other,
}
```

This new release also means that we will now be listening to feedback and accepting new features (macros, obviously). We are also now committed to maintaining this macro going forward and keeping our dependencies up to date.

## Previous release notes

If you want to take a look at the notes from previous releases, go to [GitHub Releases](https://github.com/LuisFerLCC/error-stack-macros2/releases).