### PR TITLE
Refine Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,26 @@
 version: 2
+
 updates:
+  # Production dependencies (e.g., [dependencies], [build-dependencies])
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: daily
+    allow:
+      - dependency-type: "production"
+    labels:
+      - "📦 Dependencies"
+    assignees:
+      - LuisFerLCC
+
+  # Development dependencies (e.g., [dev-dependencies])
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: "development"
+    labels:
+      - "💻 Dev Dependencies"
+    assignees:
+      - LuisFerLCC


### PR DESCRIPTION
_This is a change to the GitHub repository configuration._

I refined the dependabot.yml config file:
* Dependabot will now use the existing labels for production dependencies and development dependencies
* Dependabot will now assign the PRs to me (LuisFerLCC, the current sole maintainer)